### PR TITLE
Step 17: API authorization and data isolation

### DIFF
--- a/supabase/migration-add-user-id.sql
+++ b/supabase/migration-add-user-id.sql
@@ -1,0 +1,36 @@
+-- Migration: Add user_id column to threads table
+-- This migration can be run in Supabase's SQL Editor to update an existing database
+-- Run this script if you already have threads in your database from previous PRs
+
+-- Step 1: Add user_id column (nullable initially)
+-- We make it nullable first so we can populate it with existing user data
+ALTER TABLE threads 
+ADD COLUMN user_id uuid;
+
+-- Step 2: Set user_id for all existing threads
+-- Assign all existing threads to the first user in auth.users
+-- In a real migration, you might assign based on creation date, session logs, etc.
+UPDATE threads 
+SET user_id = (SELECT id FROM auth.users ORDER BY created_at ASC LIMIT 1)
+WHERE user_id IS NULL;
+
+-- Step 3: Make user_id NOT NULL
+-- Now that all threads have a user_id, we can enforce the constraint
+ALTER TABLE threads 
+ALTER COLUMN user_id SET NOT NULL;
+
+-- Step 4: Add foreign key constraint
+-- This ensures referential integrity between threads and users
+ALTER TABLE threads 
+ADD CONSTRAINT threads_user_id_fkey 
+FOREIGN KEY (user_id) 
+REFERENCES auth.users(id) 
+ON DELETE CASCADE;
+
+-- Step 5: Create index for performance
+-- This improves query performance when filtering threads by user
+CREATE INDEX IF NOT EXISTS threads_user_id_idx ON threads(user_id);
+
+-- Migration complete!
+-- All existing threads now belong to the first user account
+-- New threads will require a user_id (enforced by backend)

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3,6 +3,7 @@
 CREATE TABLE threads (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   title text NOT NULL,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   created_at timestamptz DEFAULT now()
 );
 
@@ -18,3 +19,7 @@ CREATE TABLE messages (
 
 -- Create index for faster queries on thread_id
 CREATE INDEX messages_thread_id_idx ON messages(thread_id);
+
+-- Create index for faster queries on user_id
+-- This improves performance when filtering threads by owner
+CREATE INDEX threads_user_id_idx ON threads(user_id);


### PR DESCRIPTION
## 📋 Table of Contents

1. [Step 1: Add user_id column to threads table for data ownership](#step-1)
2. [Step 2: Add database migration script for existing deployments](#step-2)
3. [Step 3: Set user_id when creating threads](#step-3)
4. [Step 4: Filter threads list by authenticated user](#step-4)
5. [Step 5: Authorize thread read operations](#step-5)
6. [Step 6: Authorize thread write operations](#step-6)

## 🗺️ Overview

In PR #16, you implemented authentication enforcement—the backend now verifies JWT tokens and ensures only logged-in users can access the API. But there's a critical security gap: **authenticated users can still access and modify EVERYONE's threads**!

In this tutorial, you'll implement **authorization**—the process of determining what resources a user is allowed to access. You'll establish a data ownership model where each thread belongs to a specific user, and users can only see and modify their own threads. This is called **data isolation**.

**Key Learning Outcomes:**

- Understand the difference between authentication (who you are) and authorization (what you can access)
- Implement a data ownership model using foreign keys
- Apply authorization at the database query level
- Protect all CRUD operations with ownership checks
- Learn security best practices for API responses

## 🧑‍💻 Today's starting point

If you haven't fully completed the prior tutorials, you may copy the starting point of this tutorial by running this command in the root of your local repository:

```bash
npx degit --force bewildergeist/chatbot-react-postgres#pr-17-start
```

**Important**: Make a commit of this initial version before you start changing anything.

---

<a name="step-1"></a>

## Step 1: Add user_id column to threads table for data ownership

### 🤔 Problem to solve

Currently, the `threads` table has no concept of ownership. When a user creates a thread, there's no record of who created it. This means:

- Users can see all threads in the database, not just their own
- Users can modify or delete any thread, regardless of who created it
- There's no way to filter threads by owner

You need to establish a **data ownership model** by linking each thread to the user who created it.

### 💡 Key concepts

**Foreign Keys and Relationships**

- A foreign key creates a relationship between two tables
- `REFERENCES auth.users(id)` means user_id must match an existing user ID
- This enforces **referential integrity**—you can't assign a thread to a non-existent user

**CASCADE Deletion**

- `ON DELETE CASCADE` means when a user is deleted, their threads are automatically deleted
- This maintains data consistency—no orphaned threads left behind
- Alternative: `ON DELETE SET NULL` (leaves threads but removes ownership)

**Database Indexes**

- Indexes speed up queries that filter or sort by a column
- Without an index on `user_id`, filtering threads by owner would be slow
- Indexes are especially important for foreign key columns

### 📝 Your task

Modify `supabase/schema.sql` to establish thread ownership:

1. Add a `user_id` column to the `threads` table:

   - Data type: `uuid` (matches the `id` type in `auth.users`)
   - Constraint: `NOT NULL` (every thread must have an owner)
   - Foreign key: `REFERENCES auth.users(id)` (must be a valid user)
   - On delete: `CASCADE` (delete threads when user is deleted)

2. Create an index on the `user_id` column for query performance

### 🔍 Implementation hints

**Column Definition Pattern:**

```sql
column_name data_type CONSTRAINT REFERENCES other_table(column) ON DELETE action
```

**Index Creation Pattern:**

```sql
CREATE INDEX index_name ON table_name(column_name);
```

**Where to Add:**

- Add the `user_id` column right after the `title` column in the threads table
- Add the index at the bottom of the file, after the existing `messages_thread_id_idx` index

### ✅ Reference implementation

**🔗 Commit**: [`2b0d2ab`](17/commits/2b0d2ab)

After implementing your solution, compare it with the reference commit. Notice:

- The placement of the `user_id` column in the table definition
- The syntax for foreign key constraint with CASCADE
- The naming convention for the index

### 💬 Discussion points

1. **Why NOT NULL?** What would happen if `user_id` could be `NULL`? Would that make sense for this application?

2. **Cascade vs Set Null**: In what scenarios might you choose `ON DELETE SET NULL` instead of `ON DELETE CASCADE`? When is CASCADE the better choice?

3. **Index Performance**: Why is an index particularly important for the `user_id` column? What kinds of queries will benefit from this index?

### 🧪 Test your solution

**Important**: If you're working with a fresh Supabase project, you can now run the updated `schema.sql` file in the SQL Editor to create the tables with the new structure.

However, if you already have threads in your database from previous tutorials, **do not run schema.sql again** (it will fail because the tables already exist). Instead, proceed to Step 2 where you'll use a migration script.

**Verification checklist:**

- The `user_id` column is defined with the correct data type
- The foreign key reference points to `auth.users(id)`
- The `ON DELETE CASCADE` behavior is specified
- An index is created on `user_id`
- The schema file has proper SQL syntax and comments

---

<a name="step-2"></a>

## Step 2: Add database migration script for existing deployments

### 🤔 Problem to solve

You just modified `schema.sql` to include a `user_id` column—but this file is only used when creating tables **from scratch**. If you already have a Supabase database with threads from previous tutorials, you face a challenge:

- You can't simply run `schema.sql` again (tables already exist—you'd get errors)
- You need to **alter** the existing `threads` table to add the column
- Any existing threads need to be assigned to a user (they can't have `NULL` user_id)

This is a common real-world scenario: **how do you safely update a live database without losing data?**

### 💡 Key concepts

**Database Migrations**

- A migration is a script that transforms a database from one version to another
- Unlike schema.sql (which creates from scratch), migrations modify existing structures
- Migrations should be **idempotent** when possible (safe to run multiple times)
- Professional applications use migration tools like Flyway, Liquibase, or built-in framework migrations

**Safe Column Addition Strategy**
When adding a NOT NULL column to a table with existing data:

1. Add column as **nullable** first (allows existing rows to have NULL temporarily)
2. **Populate** the column with valid data for existing rows
3. Make column **NOT NULL** (now that all rows have values)
4. Add **constraints** (foreign keys, indexes)

**Why This Order Matters**
If you try to add a `NOT NULL` column directly to a table with existing rows, the database will refuse—those existing rows would violate the constraint immediately.

### 📝 Your task

Create a new file `supabase/migration-add-user-id.sql` that safely adds the `user_id` column to an existing database.

The migration should perform these steps in order:

1. **Add nullable column**: `ALTER TABLE threads ADD COLUMN user_id uuid;`
2. **Populate existing data**: Assign all existing threads to the first user in `auth.users` (assuming that you have created at least one user through your frontend registration form, or via the Supabase Auth dashboard)
3. **Make column required**: `ALTER TABLE threads ALTER COLUMN user_id SET NOT NULL;`
4. **Add foreign key**: Create the constraint linking to `auth.users(id)` with `ON DELETE CASCADE`
5. **Create index**: Add the performance index on `user_id`

### 🔍 Implementation hints

**Getting the First User:**

```sql
SELECT id FROM auth.users ORDER BY created_at ASC LIMIT 1
```

This gets the oldest user account. You can use this in a subquery within an UPDATE statement.

**UPDATE Pattern:**

```sql
UPDATE table_name
SET column_name = (subquery)
WHERE condition;
```

**Foreign Key Constraint Pattern:**

```sql
ALTER TABLE table_name
ADD CONSTRAINT constraint_name
FOREIGN KEY (column_name)
REFERENCES other_table(other_column)
ON DELETE action;
```

**Idempotent Index Creation:**

```sql
CREATE INDEX IF NOT EXISTS index_name ON table_name(column_name);
```

The `IF NOT EXISTS` clause makes this safe to run multiple times.

### ✅ Reference implementation

**🔗 Commit**: [`91ec222`](17/commits/91ec222)

Compare your migration script with the reference. Pay attention to:

- The order of operations (nullable → populate → NOT NULL → constraint → index)
- How existing threads are assigned to a user
- The use of `IF NOT EXISTS` for idempotent operations
- Comments explaining each step for future developers

### 💬 Discussion points

1. **Data Assignment Strategy**: In this migration, all existing threads are assigned to the first user. What are other strategies you might use in a real application? (e.g., based on session logs, creation timestamps, etc.)

2. **Migration Safety**: Why is it important to add the column as nullable first, then populate it, then make it NOT NULL? What would happen if you tried to add a NOT NULL column directly?

3. **Idempotency**: Which parts of this migration are idempotent (safe to run multiple times) and which aren't? How could you make the entire migration more idempotent?

### 🧪 Test your solution

**If you have existing threads in your database:**

1. Open the Supabase Dashboard → SQL Editor
2. Paste your migration script
3. Click "Run"
4. Verify success:
   ```sql
   SELECT id, title, user_id FROM threads LIMIT 5;
   ```
   All threads should now have a `user_id` value

---

<a name="step-3"></a>

## Step 3: Set user_id when creating threads

### 🤔 Problem to solve

The database now has a `user_id` column with a NOT NULL constraint—every thread must have an owner. But your backend's `POST /api/threads` endpoint doesn't set this value when creating new threads. If you tried to create a thread right now, you'd get a database error: **"null value in column user_id violates not-null constraint"**.

You need to modify the thread creation endpoint to automatically assign the authenticated user as the owner.

### 💡 Key concepts

**Using req.userId from Authentication Middleware**
Remember from PR #16 : the `requireAuth` middleware verifies the JWT token and sets `req.userId` to the authenticated user's ID. Now you'll use this value to establish ownership.

**Ownership at Creation Time**
The best practice is to set ownership when a resource is created:

- The creator automatically becomes the owner
- No separate "assign owner" step needed
- Prevents resources from being created without ownership

**RETURNING Clause**
When you insert a row and use `RETURNING *`, you get back the complete row including all columns—generated IDs, defaults, and the values you inserted. This is useful for confirming what was created.

### 📝 Your task

Modify the `POST /api/threads` endpoint in `backend/server.js`:

1. Update the INSERT statement to include `user_id` in the column list
2. Set the value to `${req.userId}` (from the authentication middleware)
3. Update the RETURNING clause to include `user_id`
4. Update the endpoint comments to explain ownership assignment

### 🔍 Implementation hints

**Current INSERT statement structure:**

```sql
INSERT INTO threads (title)
VALUES (${trimmedTitle})
RETURNING id, title, created_at
```

**You need to:**

- Add `user_id` to the column list after `title`
- Add `${req.userId}` to the VALUES list after `${trimmedTitle}`
- Add `user_id` to the RETURNING clause

**Comment Updates:**
Look for comment sections marked with "will be used in PR #17" and update them to reflect that this is now actively using `req.userId` for authorization.

### ✅ Reference implementation

**🔗 Commit**: [`fd713f9`](17/commits/fd713f9)

Compare your implementation with the reference. Notice:

- Where `user_id` is added in the INSERT statement
- How `req.userId` is used (no quotes needed—it's a variable)
- Updated documentation in the endpoint comments
- The complete RETURNING clause that includes `user_id`

### 💬 Discussion points

1. **Automatic Ownership**: Why is it better to automatically set the owner based on `req.userId` rather than accepting a `userId` field in the request body?

2. **Trust Boundaries**: The `req.userId` comes from the verified JWT token. Why can we trust this value? What would happen if a malicious user tried to manipulate it?

3. **Foreign Key Validation**: What happens if somehow `req.userId` contains an invalid user ID that doesn't exist in `auth.users`? Will the INSERT succeed or fail?

### 🧪 Test your solution

**Create a new thread:**

1. Make sure you're logged in (go through your frontend `/login` route to get a JWT token)
2. Create a new thread through the UI
3. Check in Supabase Dashboard that the thread has the correct `user_id`

**What to verify:**

- New threads are created successfully
- The response includes the `user_id` field
- The `user_id` matches your authenticated user ID
- No database errors about null constraints

---

<a name="step-4"></a>

## Step 4: Filter threads list by authenticated user

### 🤔 Problem to solve

Your application can now create threads with proper ownership, but there's still a major security issue: **the GET /api/threads endpoint returns ALL threads from the database, regardless of who owns them**.

If you log in as User A, you see all threads—including those created by User B, User C, etc. This violates the principle of **data isolation**: users should only see their own data.

This is the core of **authorization**: not just checking if someone is logged in (authentication), but checking what they're allowed to access.

### 💡 Key concepts

**Authentication vs Authorization**

- **Authentication**: Proving who you are (PR #16 : verify JWT, set `req.userId`)
- **Authorization**: Determining what you can access (PR #17: filter by ownership)
- A user can be authenticated (logged in) but not authorized (can't access someone else's data)

**Query-Level Authorization**
The most secure approach is to filter data **at the database query level**:

```sql
WHERE user_id = ${req.userId}
```

This means unauthorized data is never loaded from the database—it can't leak through bugs or logging.

**Why Not Filter in JavaScript?**
You could fetch all threads and filter in JavaScript:

```javascript
const allThreads = await sql`SELECT * FROM threads`;
const userThreads = allThreads.filter((t) => t.user_id === req.userId);
```

But this is dangerous:

- All data is loaded into memory (performance issue)
- Unauthorized data is briefly accessible (security risk)
- Easy to forget the filter and leak data
- Database indexes can't optimize the query

### 📝 Your task

Modify the `GET /api/threads` endpoint in `backend/server.js`:

1. Add a WHERE clause to filter threads by `user_id = ${req.userId}`
2. Include `user_id` in the SELECT clause (for consistency with the schema)
3. Update the endpoint comments to explain authorization

### 🔍 Implementation hints

**Current query structure:**

```sql
SELECT id, title, created_at
FROM threads
ORDER BY created_at DESC
```

**Add WHERE clause:**

- Place it after `FROM threads` and before `ORDER BY`
- Use `WHERE user_id = ${req.userId}` to filter by the authenticated user
- Make sure `user_id` is included in the SELECT column list

**Comment Updates:**
Update the Authentication/Authorization comment sections to reflect:

- That `req.userId` is now actively used (not "will be used in PR #17")
- Explain the concept of data isolation
- Clarify the difference between authentication and authorization

### ✅ Reference implementation

**🔗 Commit**: [`1f52782`](17/commits/1f52782)

Study the reference implementation and notice:

- The placement of the WHERE clause in the SQL query
- How `user_id` is added to the SELECT clause
- The updated comments explaining authorization vs authentication
- How simple the implementation is (one WHERE clause changes everything!)

### 💬 Discussion points

1. **Security by Default**: Why is filtering at the database query level more secure than filtering the results in JavaScript code?

2. **Index Performance**: How does the index on `user_id` (from Step 1) improve the performance of this query?

3. **Defense in Depth**: Even with this WHERE clause, why is it still important to verify the JWT token with authentication middleware?

### 🧪 Test your solution

**Test with multiple users:**

1. **Create a second user account** (if you don't have one yet):

   - Register a new account through your UI (disable email verification via the Supabase Auth settings while testing)

2. **Test data isolation:**

   - Log in as User A, create some threads
   - Log out, log in as User B, create different threads
   - Log back in as User A
   - Verify you ONLY see User A's threads (not User B's)

3. **Inspect the Network tab:**
   - Open browser DevTools → Network
   - Refresh the threads list
   - Look at the response from `GET /api/threads`
   - Confirm it only contains your threads

**Expected behavior:**

- Each user sees only their own threads
- Creating a thread with User A doesn't make it visible to User B
- The API response only contains threads where `user_id` matches your token

**💡 Think About This**: What happens if you try to manually craft a request with someone else's user ID? Why doesn't that work?

---

<a name="step-5"></a>

## Step 5: Authorize thread read operations

### 🤔 Problem to solve

You've secured the threads list, but individual thread endpoints still have security holes:

- `GET /api/threads/:id` returns ANY thread if you know its ID
- `GET /api/threads/:id/messages` returns messages from ANY thread

A malicious user could:

1. Try random UUIDs until they find valid thread IDs
2. Access threads they don't own by guessing or intercepting IDs
3. Read private conversations that don't belong to them

You need to add ownership checks to these read operations.

### 💡 Key concepts

**Authorization on Individual Resources**
When accessing a specific resource by ID, you must verify:

1. The resource exists
2. The current user owns the resource (or has permission to access it)

**Security Through Information Hiding**
When a user tries to access an unauthorized resource, return **404 Not Found** instead of **403 Forbidden**. Why?

- **404**: "This doesn't exist" (user can't tell if ID is valid)
- **403**: "This exists but you can't access it" (confirms ID is valid!)

By using 404, you prevent attackers from discovering valid resource IDs through trial and error.

**Two-Step Authorization Pattern**
For nested resources like `/threads/:id/messages`:

1. First check: Does the thread exist AND does user own it?
2. Second step: If yes, fetch the messages

This prevents leaking message data from unauthorized threads.

### 📝 Your task

Modify two endpoints in `backend/server.js`:

**1. GET /api/threads/:id**

- Add `AND user_id = ${req.userId}` to the WHERE clause
- Include `user_id` in the SELECT clause
- Update comments to explain authorization

**2. GET /api/threads/:id/messages**

- BEFORE fetching messages, verify thread ownership
- Add a query to check if the thread exists with the correct user_id
- If unauthorized, return an empty array `[]` (not 404)
- Only fetch messages if the thread is owned by the user
- Update comments to explain the two-step authorization

### 🔍 Implementation hints

**For GET /api/threads/:id:**

Current WHERE clause:

```sql
WHERE id = ${threadId}
```

Add ownership check:

```sql
WHERE id = ${threadId} AND user_id = ${req.userId}
```

**For GET /api/threads/:id/messages:**

Add this BEFORE fetching messages:

```javascript
// Step 1: Verify thread ownership
const threads = await sql`
  SELECT id 
  FROM threads 
  WHERE id = ${threadId} AND user_id = ${req.userId}
`;

// Step 2: If thread doesn't exist or user doesn't own it
if (threads.length === 0) {
  return res.json([]); // Empty array, not 404
}

// Step 3: Now safe to fetch messages
// ... existing messages query
```

**Why empty array for messages?**
An empty array looks like "this thread has no messages yet" rather than "you're not authorized". This prevents information leakage.

### ✅ Reference implementation

**🔗 Commit**: [`3700652`](17/commits/3700652)

Compare your implementation with the reference. Pay attention to:

- The composite WHERE clause (both ID and user_id)
- The two-step pattern in the messages endpoint
- Why 404 is used for threads but empty array for messages
- Updated comment sections explaining the security design

### 💬 Discussion points

1. **404 vs 403**: Why is it more secure to return 404 (Not Found) rather than 403 (Forbidden) when a user tries to access someone else's thread?

2. **Empty Array Strategy**: For `/threads/:id/messages`, why return an empty array instead of 404 when the thread is unauthorized? How does this prevent information leakage?

3. **Attack Scenarios**: How does this implementation protect against:
   - A user trying random thread UUIDs?
   - A user intercepting thread IDs from network traffic?
   - A user bookmarking someone else's thread URL?

### 🧪 Test your solution

**Test unauthorized access:**

1. **Get a thread ID from another user:**

   - Log in as User A, note a thread ID
   - Log out, log in as User B
   - Try to access User A's thread directly

2. **Test via browser:**

   - Navigate to `/chat/:threadId` with another user's thread ID
   - You should get redirected or see an error (thread not found)

3. **Test via API:**

   ```bash
   # Try to access another user's thread
   curl http://localhost:3000/api/threads/OTHER_USER_THREAD_ID \
     -H "Authorization: Bearer YOUR_JWT_TOKEN"
   ```

   Should return 404

4. **Test messages endpoint:**
   ```bash
   # Try to fetch messages from unauthorized thread
   curl http://localhost:3000/api/threads/OTHER_USER_THREAD_ID/messages \
     -H "Authorization: Bearer YOUR_JWT_TOKEN"
   ```
   Should return empty array `[]`

**Expected behavior:**

- Cannot access other users' threads (404 response)
- Cannot see messages from unauthorized threads (empty array)
- Can still access your own threads normally
- Frontend handles these responses gracefully

---

<a name="step-6"></a>

## Step 6: Authorize thread write operations

### 🤔 Problem to solve

You've secured read operations, but write operations are still vulnerable:

- `POST /api/threads/:id/messages` - Anyone can add messages to any thread
- `PATCH /api/threads/:id` - Anyone can rename any thread
- `DELETE /api/threads/:id` - Anyone can delete any thread

A malicious user could:

- Spam messages into other users' threads
- Rename threads to offensive content
- Delete threads they don't own

You need to add ownership verification before allowing any modifications.

### 💡 Key concepts

**Write Authorization is Critical**
While unauthorized reads are a privacy issue, unauthorized writes can:

- Destroy data (deletions)
- Corrupt data (unwanted modifications)
- Inject malicious content (spam, XSS attempts)
- Damage user trust completely

**Authorization Patterns for Write Operations**

**Pattern 1: Check Before Write (POST messages)**

```javascript
// 1. Verify ownership
const threads = await sql`SELECT id FROM threads WHERE id = ? AND user_id = ?`;
if (threads.length === 0) return res.status(404);

// 2. Perform write
const result = await sql`INSERT INTO messages ...`;
```

**Pattern 2: WHERE Clause Authorization (UPDATE/DELETE)**

```javascript
// Single query that combines check + write
const result = await sql`
  UPDATE threads 
  SET ... 
  WHERE id = ${id} AND user_id = ${req.userId}
`;

// If no rows affected, thread didn't exist or wasn't owned
if (result.length === 0) return res.status(404);
```

Pattern 2 is more efficient (one query) and atomic (no race conditions).

**Consistent Error Responses**
Like with read operations, return 404 for unauthorized write attempts to prevent information disclosure.

### 📝 Your task

Modify three write endpoints in `backend/server.js`:

**1. POST /api/threads/:id/messages**

- Add ownership verification BEFORE inserting the message
- Check if thread exists AND user owns it
- Return 404 if unauthorized
- Update comments

**2. PATCH /api/threads/:id**

- Add `AND user_id = ${req.userId}` to the UPDATE WHERE clause
- Include `user_id` in RETURNING clause
- Update the error message comment
- Update endpoint comments

**3. DELETE /api/threads/:id**

- Add `AND user_id = ${req.userId}` to the DELETE WHERE clause
- Update the error message comment
- Update endpoint comments

### 🔍 Implementation hints

**For POST /api/threads/:id/messages:**

Add this AFTER input validation but BEFORE the INSERT:

```javascript
// Authorization check: Verify the thread exists AND is owned by the user
const threads = await sql`
  SELECT id 
  FROM threads 
  WHERE id = ${threadId} AND user_id = ${req.userId}
`;

// If thread doesn't exist or user doesn't own it, return 404
if (threads.length === 0) {
  return res.status(404).json({
    error: "Thread not found",
  });
}

// Now safe to insert the message
// ... existing INSERT statement
```

**For PATCH /api/threads/:id:**

Current WHERE clause:

```sql
WHERE id = ${threadId}
```

Change to:

```sql
WHERE id = ${threadId} AND user_id = ${req.userId}
```

**For DELETE /api/threads/:id:**

Same pattern—add `AND user_id = ${req.userId}` to the WHERE clause.

**Comment Updates:**
Update sections that say "will be used in PR #17" and add explanations about write authorization and preventing unauthorized modifications.

### ✅ Reference implementation

**🔗 Commit**: [`4553a13`](17/commits/4553a13)

Study the reference implementation carefully:

- The two different patterns used (check-then-write vs WHERE clause)
- Why POST messages needs explicit checking (you're inserting into messages table, not threads)
- How UPDATE and DELETE use WHERE clauses for authorization
- The consistency of 404 responses for all unauthorized attempts
- Comprehensive comment updates explaining security decisions

### 💬 Discussion points

1. **Two Patterns**: Why does POST /api/threads/:id/messages use a separate ownership check, while PATCH and DELETE use WHERE clause authorization? What's the difference?

2. **Race Conditions**: Could there be a race condition between checking ownership and inserting a message? What could happen if a thread is deleted between those two operations?

3. **Complete Protection**: With all CRUD operations now authorized, what attack vectors have you closed? Can you think of any remaining security concerns?

### 🧪 Test your solution

**Test unauthorized writes:**

1. **Try to add message to another user's thread (via curl, Postman, Thunder Client, httpie):**

   ```bash
   curl -X POST http://localhost:3000/api/threads/OTHER_USER_THREAD_ID/messages \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer YOUR_JWT_TOKEN" \
     -d '{"type":"user","content":"Hacking!"}'
   ```

   Should return 404

2. **Try to rename another user's thread:**

   ```bash
   curl -X PATCH http://localhost:3000/api/threads/OTHER_USER_THREAD_ID \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer YOUR_JWT_TOKEN" \
     -d '{"title":"Hacked Title"}'
   ```

   Should return 404

3. **Try to delete another user's thread:**

   ```bash
   curl -X DELETE http://localhost:3000/api/threads/OTHER_USER_THREAD_ID \
     -H "Authorization: Bearer YOUR_JWT_TOKEN"
   ```

   Should return 404

4. **Verify your own threads still work:**
   - Create messages in your threads ✓
   - Rename your threads ✓
   - Delete your threads ✓

**Security verification:**

- Cannot add messages to unauthorized threads
- Cannot update unauthorized threads
- Cannot delete unauthorized threads
- All unauthorized attempts return 404
- Your own write operations work normally

---

## 🎉 Congratulations!

You've successfully implemented **complete authorization and data isolation** in your chatbot application! This is a critical milestone in building secure web applications.

### What you've accomplished

**Security Transformation:**

- ✅ Established a data ownership model with foreign keys
- ✅ Implemented authorization for all read operations
- ✅ Protected all write operations with ownership checks
- ✅ Applied security best practices (404 vs 403, query-level filtering)
- ✅ Created safe database migration for existing deployments

**Key Concepts Mastered:**

- **Authentication vs Authorization**: You now understand the difference and why both are essential
- **Data Isolation**: Each user's data is completely separate from others
- **Query-Level Security**: Authorization happens at the database, not in application code
- **Foreign Key Relationships**: Using database constraints to enforce data integrity
- **Secure API Design**: Preventing information leakage through error responses

**Before and After:**

- **Before PR #17**: Any logged-in user could see and modify everyone's threads
- **After PR #17**: Users can only access their own data—complete isolation

### The Security Layers

You've now implemented all three critical security layers:

1. **Authentication (PR #14-#15)**: User accounts and login system
2. **Token Transmission (PR #15)**: Sending JWT tokens with requests
3. **Token Verification (PR #16)**: Backend validates tokens
4. **Authorization (PR #17)**: Users can only access their own data ← You are here!

Your application is now production-ready from a basic security perspective! 🔒

## 🚀 Extra challenges (if you have time)

Want to explore further? Try these extensions:

### Challenge 1: Manual audit logging in endpoints

Add logging statements directly in each endpoint to understand what's being accessed:

- In each endpoint (GET, POST, PATCH, DELETE), add console.log statements
- Log: `user_id`, `method`, `endpoint`, `timestamp`
- Example: `console.log('User ${req.userId} accessed ${req.method} ${req.path} at ${new Date().toISOString()}')`
- This helps you see patterns in how users interact with the API

**Why this step?** Understanding what to log before abstracting it into middleware.

### Challenge 2: Centralized audit logging via middleware

Move the logging logic from individual endpoints to a reusable middleware:

- Create an `auditLog` middleware function
- Place it after `requireAuth` in the middleware chain
- Log the same information (user_id, method, path, timestamp)
- Apply it to all protected routes

**Why this step?** DRY principle—don't repeat logging code in every endpoint. Middleware centralizes cross-cutting concerns.

### Challenge 3: Persistent audit logging via database

Create a permanent audit trail by storing logs in the database:

- Create an `audit_log` table in `schema.sql`
  - Columns: `id`, `user_id`, `action` (method), `resource` (path), `timestamp`
- Modify the audit middleware to INSERT into `audit_log` instead of console.log
- Create queries to analyze the audit trail (e.g., "show all actions by user X")
- Consider adding indexes on `user_id` and `timestamp` for query performance
- Think of how an admin dashboard could visualize this data

**Why this step?** Console logs disappear on restart (if you don't manually save them). Database logs enable security analysis, compliance, and debugging historical issues.

## 📚 Additional resources

- [OWASP Authorization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html) if you want to dive deeper into best practices
- [PostgreSQL Foreign Keys](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK)
- [HTTP Status Codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status)
